### PR TITLE
fix/conventions

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "ap-southeast-1"
 }
 
-module "public-route53-hosted-zone" {
+module "public_route53_hosted_zone" {
   source         = "../.."
   name           = "fpr.traveloka.com"
   product_domain = "fpr"

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -7,5 +7,4 @@ module "public-route53-hosted-zone" {
   name           = "fpr.traveloka.com"
   product_domain = "fpr"
   environment    = "production"
-  description    = "Flight Product route53 hosted zone"
 }

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -1,0 +1,9 @@
+output "zone_id" {
+  value       = "${module.public_route53_hosted_zone.zone_id}"
+  description = "The hosted zone id"
+}
+
+output "name_servers" {
+  value       = "${module.public_route53_hosted_zone.name_servers}"
+  description = "A list of name servers in associated (or default) delegation set"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,10 @@
+locals {
+  description = "Public zone for ${var.name}"
+}
+
 resource "aws_route53_zone" "this" {
   name              = "${var.name}"
-  comment           = "${var.description}"
+  comment           = "${local.description}"
   delegation_set_id = "${var.delegation_set_id}"
   force_destroy     = "${var.force_destroy}"
 
@@ -8,6 +12,7 @@ resource "aws_route53_zone" "this" {
     "Name"          = "${var.name}"
     "ProductDomain" = "${var.product_domain}"
     "Environment"   = "${var.environment}"
-    "Description"   = "${var.description}"
+    "Description"   = "${local.description}"
+    "ManagedBy"     = "Terraform"
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "zone_id" {
   value       = "${aws_route53_zone.this.zone_id}"
   description = "The hosted zone id"
 }
+
+output "name_servers" {
+  value       = "${aws_route53_zone.this.name_servers}"
+  description = "A list of name servers in associated (or default) delegation set"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,11 +13,6 @@ variable "environment" {
   description = "Environment this Route 53 zone belongs to"
 }
 
-variable "description" {
-  type        = "string"
-  description = "Description of the hosted zone"
-}
-
 variable "delegation_set_id" {
   type        = "string"
   default     = ""


### PR DESCRIPTION
CHANGES:

* New tag: `ManagedBy = Terraform`
* Remove variable: `description`
* Add output: `name_servers` (will probably needed to add the NS of this zone as route53 record to the parent zone)

Will be considered as minor version increase